### PR TITLE
Customizable Screenshot Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Random Screenshot
 A RuneLite plugin that takes random screenshots as you go about your adventures.
 
-You can find your randomly taken screenshots under the `Random Screenshots` folder in your RuneLite Screenshots folder.
+By default, you can find your randomly taken screenshots under the `Random Screenshots` folder in your RuneLite 
+Screenshots folder. You may also configure a custom folder to save your screenshots to. Note that if you sync your 
+RuneLite settings across multiple devices, your custom directory might not be valid on all of them!
 
 Feel free to suggest improvements/features on this repository's issues page, or submit a pull request!
 
-## Configuration
+## Screenshot Frequency
 Every game tick, there is a 1 in `n` chance that a screenshot is taken (with `n` configurable via the "Sample Weight"
 option). _This does not guarantee a screenshot will be taken every `n` ticks! It's random!_ Moreover, the roll to take a
 screenshot does not happen whenever the bank pin UI is open.

--- a/src/main/java/com/randomscreenshot/FileFactory.java
+++ b/src/main/java/com/randomscreenshot/FileFactory.java
@@ -21,8 +21,11 @@ public class FileFactory
 	@Inject
 	private Client client;
 
-	public File createScreenshotFile(String directory) throws IOException {
-		File screenshotDirectory = createScreenshotDirectory(directory);
+	@Inject
+	private RandomScreenshotConfig config;
+
+	public File createScreenshotFile() throws IOException {
+		File screenshotDirectory = createScreenshotDirectory();
 		String fileName = format(new Date());
 
 		File screenshotFile = new File(screenshotDirectory, fileName + ".png");
@@ -44,16 +47,19 @@ public class FileFactory
 	 *
 	 * If path is an empty string, the player profile directory is used instead.
 	 */
-	public File createScreenshotDirectory(String path) throws IOException {
+	public File createScreenshotDirectory() throws IOException {
 		File screenshotDirectory;
-		if (!path.isEmpty()) {
-			screenshotDirectory = new File(path);
+		if (config.useCustomDirectory())
+		{
+			screenshotDirectory = new File(config.screenshotDirectory());
 		}
-		else {
+		else
+		{
 			screenshotDirectory = getPlayerScreenshotDirectory();
 		}
 
-		if (!screenshotDirectory.mkdirs() && !screenshotDirectory.exists()) {
+		if (!screenshotDirectory.mkdirs() && !screenshotDirectory.exists())
+		{
 			throw new IOException("Could not create screenshot directory at " + screenshotDirectory.getAbsolutePath());
 		}
 

--- a/src/main/java/com/randomscreenshot/FileFactory.java
+++ b/src/main/java/com/randomscreenshot/FileFactory.java
@@ -1,0 +1,94 @@
+package com.randomscreenshot;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
+import net.runelite.client.config.RuneScapeProfileType;
+import net.runelite.client.util.Text;
+
+@Singleton
+@Slf4j
+public class FileFactory
+{
+	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+	@Inject
+	private Client client;
+
+	public File createScreenshotFile(String directory) throws IOException {
+		File screenshotDirectory = createScreenshotDirectory(directory);
+		String fileName = format(new Date());
+
+		File screenshotFile = new File(screenshotDirectory, fileName + ".png");
+
+		// To make sure that screenshots don't get overwritten, check if file exists,
+		// and if it does create file with same name and suffix.
+		int i = 1;
+		while (screenshotFile.exists())
+		{
+			screenshotFile = new File(screenshotDirectory, fileName + String.format("(%d)", i++) + ".png");
+		}
+
+		return screenshotFile;
+	}
+
+	/**
+	 * Create a directory at `path` if one does not exist, and return the
+	 * corresponding `File` object.
+	 *
+	 * If path is an empty string, the player profile directory is used instead.
+	 */
+	public File createScreenshotDirectory(String path) throws IOException {
+		File screenshotDirectory;
+		if (!path.isEmpty()) {
+			screenshotDirectory = new File(path);
+		}
+		else {
+			screenshotDirectory = getPlayerScreenshotDirectory();
+		}
+
+		if (!screenshotDirectory.mkdirs() && !screenshotDirectory.exists()) {
+			throw new IOException("Could not create screenshot directory at " + screenshotDirectory.getAbsolutePath());
+		}
+
+		return screenshotDirectory;
+	}
+
+	private File getPlayerScreenshotDirectory() {
+		File directory;
+
+		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+		{
+			String playerDir = client.getLocalPlayer().getName();
+			RuneScapeProfileType profileType = RuneScapeProfileType.getCurrent(client);
+			if (profileType != RuneScapeProfileType.STANDARD)
+			{
+				playerDir += "-" + Text.titleCase(profileType);
+			}
+			playerDir += File.separator + "Random Screenshots";
+
+			directory = new File(SCREENSHOT_DIR, playerDir);
+		}
+		else
+		{
+			directory = SCREENSHOT_DIR;
+		}
+
+		return directory;
+
+	}
+
+	private static String format(Date date)
+	{
+		synchronized (TIME_FORMAT)
+		{
+			return TIME_FORMAT.format(date);
+		}
+	}
+}

--- a/src/main/java/com/randomscreenshot/RandomScreenshotConfig.java
+++ b/src/main/java/com/randomscreenshot/RandomScreenshotConfig.java
@@ -26,13 +26,33 @@ public interface RandomScreenshotConfig extends Config
 		return 500;
 	}
 
+	/* TODO: Ideally we'd use a file picker here, but the file picker is not available to the plugin config panel and
+	    making it available requires changes to core runelite. */
 	@ConfigItem(
 		keyName = "screenshotDirectory",
-		name = "Screenshot Directory",
+		name = "Custom Screenshot Directory",
 		description = "Custom directory to save screenshots to",
-		section = customDirectorySection
+		section = customDirectorySection,
+		position = 1
 	)
 	default String screenshotDirectory() {
 		return "";
+	}
+
+	@ConfigItem(
+		keyName = "useCustomDirectory",
+		name = "Use Custom Screenshot Directory",
+		description = "Save screenshots to the configured custom directory",
+		warning =
+			"When enabling this option, make sure that the directory you've configured is valid! " +
+			"If it isn't, screenshots will be lost!\n\n" +
+			"Also note: if you sync your RuneLite settings across multiple computers, " +
+			"please make sure the given directory is valid on all your computers!\n\n" +
+			"You can disregard this message if you are just disabling this option.",
+		section = customDirectorySection,
+		position = 2
+	)
+	default boolean useCustomDirectory() {
+		return false;
 	}
 }

--- a/src/main/java/com/randomscreenshot/RandomScreenshotConfig.java
+++ b/src/main/java/com/randomscreenshot/RandomScreenshotConfig.java
@@ -3,11 +3,19 @@ package com.randomscreenshot;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
 
 @ConfigGroup(RandomScreenshotPlugin.CONFIG_GROUP_KEY)
 public interface RandomScreenshotConfig extends Config
 {
+	@ConfigSection(
+		name = "Custom Directory",
+		description = "Custom setting for where to save screenshots",
+		position = 99
+	)
+	String customDirectorySection = "Custom Directory";
+
 	@ConfigItem(
 		keyName = "sampleWeight",
 		name = "Sample Weight",
@@ -16,5 +24,15 @@ public interface RandomScreenshotConfig extends Config
 	@Range(min = 1)
 	default int sampleWeight() {
 		return 500;
+	}
+
+	@ConfigItem(
+		keyName = "screenshotDirectory",
+		name = "Screenshot Directory",
+		description = "Custom directory to save screenshots to",
+		section = customDirectorySection
+	)
+	default String screenshotDirectory() {
+		return "";
 	}
 }

--- a/src/main/java/com/randomscreenshot/RandomScreenshotPlugin.java
+++ b/src/main/java/com/randomscreenshot/RandomScreenshotPlugin.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -52,20 +53,28 @@ public class RandomScreenshotPlugin extends Plugin
 
 	/* TODO: Create a decider interface so that decision strategy can be made modular. */
 	private boolean shouldTakeScreenshot() {
-		return isBankPINContainerHidden() && rand.nextInt(config.sampleWeight()) == 0;
+		if (isBankPinContainerVisible() || isOnLoginScreen()) {
+			return false;
+		}
+
+		return rand.nextInt(config.sampleWeight()) == 0;
 	}
 
 	private void takeScreenshot() {
 		screenShotUtil.takeScreenshot(config.screenshotDirectory());
 	}
 
-	private boolean isBankPINContainerHidden()
+	private boolean isBankPinContainerVisible()
 	{
 		Widget pinContainer = client.getWidget(WidgetInfo.BANK_PIN_CONTAINER);
 		if (pinContainer == null) {
 			return true;
 		}
 
-		return pinContainer.isSelfHidden();
+		return !pinContainer.isSelfHidden();
+	}
+
+	private boolean isOnLoginScreen() {
+		return client.getGameState() == GameState.LOGIN_SCREEN;
 	}
 }

--- a/src/main/java/com/randomscreenshot/RandomScreenshotPlugin.java
+++ b/src/main/java/com/randomscreenshot/RandomScreenshotPlugin.java
@@ -61,7 +61,7 @@ public class RandomScreenshotPlugin extends Plugin
 	}
 
 	private void takeScreenshot() {
-		screenShotUtil.takeScreenshot(config.screenshotDirectory());
+		screenShotUtil.takeScreenshot();
 	}
 
 	private boolean isBankPinContainerVisible()

--- a/src/main/java/com/randomscreenshot/RandomScreenshotPlugin.java
+++ b/src/main/java/com/randomscreenshot/RandomScreenshotPlugin.java
@@ -56,7 +56,7 @@ public class RandomScreenshotPlugin extends Plugin
 	}
 
 	private void takeScreenshot() {
-		screenShotUtil.takeScreenshot("", "Random Screenshots");
+		screenShotUtil.takeScreenshot(config.screenshotDirectory());
 	}
 
 	private boolean isBankPINContainerHidden()

--- a/src/main/java/com/randomscreenshot/ScreenshotUtil.java
+++ b/src/main/java/com/randomscreenshot/ScreenshotUtil.java
@@ -29,9 +29,6 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import javax.imageio.ImageIO;
@@ -40,28 +37,25 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
-import net.runelite.client.config.RuneScapeProfileType;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.events.ScreenshotTaken;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.util.ImageUtil;
-import net.runelite.client.util.Text;
 
 @Singleton
 @Slf4j
 public class ScreenshotUtil
 {
-	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
-
-	@Inject
-	private Client client;
 	@Inject
 	private DrawManager drawManager;
 	@Inject
 	private ScheduledExecutorService executor;
 	@Inject
 	private EventBus eventBus;
+	@Inject
+	private Client client;
+	@Inject
+	private FileFactory fileFactory;
 	
 	public void takeScreenshot(String directory)
 	{
@@ -73,24 +67,20 @@ public class ScreenshotUtil
 		Consumer<Image> imageCallback = (img) ->
 		{
 			// This callback is on the game thread, move to executor thread
-			executor.submit(() -> saveScreenshot(ImageUtil.bufferedImageFromImage(img), directory));
+			executor.submit(() -> saveScreenshot(img, directory));
 		};
 
 		drawManager.requestNextFrameListener(imageCallback);
 	}
 
-	private void saveScreenshot(BufferedImage screenshot, String directory)
+	private void saveScreenshot(Image image, String directory)
 	{
+		BufferedImage screenshot = ImageUtil.bufferedImageFromImage(image);
 
-		if (client.getGameState() == GameState.LOGIN_SCREEN)
-		{
-			log.debug("Login screenshot prevented");
-			return;
-		}
-
-		File screenshotFile = getScreenshotFile(directory);
+		File screenshotFile;
 		try
 		{
+			screenshotFile = fileFactory.createScreenshotFile(directory);
 			ImageIO.write(screenshot, "PNG", screenshotFile);
 		}
 		catch (IOException ex)
@@ -99,76 +89,10 @@ public class ScreenshotUtil
 			return;
 		}
 
-
 		ScreenshotTaken screenshotTaken = new ScreenshotTaken(
 			screenshotFile,
 			screenshot
 		);
 		eventBus.post(screenshotTaken);
-	}
-
-	// TODO: Maybe it'd be best to move all this logic for getting the screenshot file
-	//  to be separate from the screenshot code.
-	private File getScreenshotFile(String directory) {
-		String fileName = "";
-
-		File screenshotDirectory = getOrCreateScreenshotDirectory(directory, client);
-		screenshotDirectory.mkdirs();
-
-		fileName += (fileName.isEmpty() ? "" : " ") + format(new Date());
-		File screenshotFile = new File(screenshotDirectory, fileName + ".png");
-
-		// To make sure that screenshots don't get overwritten, check if file exists,
-		// and if it does create file with same name and suffix.
-		int i = 1;
-		while (screenshotFile.exists())
-		{
-			screenshotFile = new File(screenshotDirectory, fileName + String.format("(%d)", i++) + ".png");
-		}
-
-		return screenshotFile;
-	}
-
-	private File getOrCreateScreenshotDirectory(String directory, Client client) {
-		File screenshotDirectory;
-		if (!directory.isEmpty()) {
-			screenshotDirectory = new File(directory);
-		}
-		else {
-			screenshotDirectory = getDefaultScreenshotDirectory(client);
-		}
-
-		return screenshotDirectory;
-	}
-
-	private File getDefaultScreenshotDirectory(Client client) {
-		File directory;
-
-		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
-		{
-			String playerDir = client.getLocalPlayer().getName();
-			RuneScapeProfileType profileType = RuneScapeProfileType.getCurrent(client);
-			if (profileType != RuneScapeProfileType.STANDARD)
-			{
-				playerDir += "-" + Text.titleCase(profileType);
-			}
-			playerDir += File.separator + "Random Screenshots";
-
-			directory = new File(SCREENSHOT_DIR, playerDir);
-		}
-		else
-		{
-			directory = SCREENSHOT_DIR;
-		}
-
-		return directory;
-	}
-
-	private static String format(Date date)
-	{
-		synchronized (TIME_FORMAT)
-		{
-			return TIME_FORMAT.format(date);
-		}
 	}
 }

--- a/src/main/java/com/randomscreenshot/ScreenshotUtil.java
+++ b/src/main/java/com/randomscreenshot/ScreenshotUtil.java
@@ -53,25 +53,25 @@ public class ScreenshotUtil
 	@Inject
 	private FileFactory fileFactory;
 	
-	public void takeScreenshot(String directory)
+	public void takeScreenshot()
 	{
 		Consumer<Image> imageCallback = (img) ->
 		{
 			// This callback is on the game thread, move to executor thread
-			executor.submit(() -> saveScreenshot(img, directory));
+			executor.submit(() -> saveScreenshot(img));
 		};
 
 		drawManager.requestNextFrameListener(imageCallback);
 	}
 
-	private void saveScreenshot(Image image, String directory)
+	private void saveScreenshot(Image image)
 	{
 		BufferedImage screenshot = ImageUtil.bufferedImageFromImage(image);
 
 		File screenshotFile;
 		try
 		{
-			screenshotFile = fileFactory.createScreenshotFile(directory);
+			screenshotFile = fileFactory.createScreenshotFile();
 			ImageIO.write(screenshot, "PNG", screenshotFile);
 		}
 		catch (IOException ex)

--- a/src/main/java/com/randomscreenshot/ScreenshotUtil.java
+++ b/src/main/java/com/randomscreenshot/ScreenshotUtil.java
@@ -26,20 +26,33 @@
 package com.randomscreenshot;
 
 import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
+import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import static net.runelite.client.RuneLite.SCREENSHOT_DIR;
+import net.runelite.client.config.RuneScapeProfileType;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.events.ScreenshotTaken;
 import net.runelite.client.ui.DrawManager;
-import net.runelite.client.util.ImageCapture;
-import net.runelite.client.util.ImageUploadStyle;
 import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.Text;
 
 @Singleton
+@Slf4j
 public class ScreenshotUtil
 {
+	private static final DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 
 	@Inject
 	private Client client;
@@ -48,16 +61,9 @@ public class ScreenshotUtil
 	@Inject
 	private ScheduledExecutorService executor;
 	@Inject
-	private ImageCapture imageCapture;
+	private EventBus eventBus;
 	
-	/**
-	 * Saves a screenshot of the client window to the screenshot folder as a PNG,
-	 * and optionally uploads it to an image-hosting service.
-	 *
-	 * @param fileName Filename to use, without file extension.
-	 * @param subDir   Subdirectory to store the captured screenshot in.
-	 */
-	public void takeScreenshot(String fileName, String subDir)
+	public void takeScreenshot(String directory)
 	{
 		if (client.getGameState() == GameState.LOGIN_SCREEN)
 		{
@@ -67,14 +73,102 @@ public class ScreenshotUtil
 		Consumer<Image> imageCallback = (img) ->
 		{
 			// This callback is on the game thread, move to executor thread
-			executor.submit(() -> takeScreenshot(fileName, subDir, img));
+			executor.submit(() -> saveScreenshot(ImageUtil.bufferedImageFromImage(img), directory));
 		};
 
 		drawManager.requestNextFrameListener(imageCallback);
 	}
-	
-	private void takeScreenshot(String fileName, String subDir, Image image)
+
+	private void saveScreenshot(BufferedImage screenshot, String directory)
 	{
-		imageCapture.takeScreenshot(ImageUtil.bufferedImageFromImage(image), fileName, subDir, false, ImageUploadStyle.NEITHER);
+
+		if (client.getGameState() == GameState.LOGIN_SCREEN)
+		{
+			log.debug("Login screenshot prevented");
+			return;
+		}
+
+		File screenshotFile = getScreenshotFile(directory);
+		try
+		{
+			ImageIO.write(screenshot, "PNG", screenshotFile);
+		}
+		catch (IOException ex)
+		{
+			log.error("error writing screenshot", ex);
+			return;
+		}
+
+
+		ScreenshotTaken screenshotTaken = new ScreenshotTaken(
+			screenshotFile,
+			screenshot
+		);
+		eventBus.post(screenshotTaken);
+	}
+
+	// TODO: Maybe it'd be best to move all this logic for getting the screenshot file
+	//  to be separate from the screenshot code.
+	private File getScreenshotFile(String directory) {
+		String fileName = "";
+
+		File screenshotDirectory = getOrCreateScreenshotDirectory(directory, client);
+		screenshotDirectory.mkdirs();
+
+		fileName += (fileName.isEmpty() ? "" : " ") + format(new Date());
+		File screenshotFile = new File(screenshotDirectory, fileName + ".png");
+
+		// To make sure that screenshots don't get overwritten, check if file exists,
+		// and if it does create file with same name and suffix.
+		int i = 1;
+		while (screenshotFile.exists())
+		{
+			screenshotFile = new File(screenshotDirectory, fileName + String.format("(%d)", i++) + ".png");
+		}
+
+		return screenshotFile;
+	}
+
+	private File getOrCreateScreenshotDirectory(String directory, Client client) {
+		File screenshotDirectory;
+		if (!directory.isEmpty()) {
+			screenshotDirectory = new File(directory);
+		}
+		else {
+			screenshotDirectory = getDefaultScreenshotDirectory(client);
+		}
+
+		return screenshotDirectory;
+	}
+
+	private File getDefaultScreenshotDirectory(Client client) {
+		File directory;
+
+		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+		{
+			String playerDir = client.getLocalPlayer().getName();
+			RuneScapeProfileType profileType = RuneScapeProfileType.getCurrent(client);
+			if (profileType != RuneScapeProfileType.STANDARD)
+			{
+				playerDir += "-" + Text.titleCase(profileType);
+			}
+			playerDir += File.separator + "Random Screenshots";
+
+			directory = new File(SCREENSHOT_DIR, playerDir);
+		}
+		else
+		{
+			directory = SCREENSHOT_DIR;
+		}
+
+		return directory;
+	}
+
+	private static String format(Date date)
+	{
+		synchronized (TIME_FORMAT)
+		{
+			return TIME_FORMAT.format(date);
+		}
 	}
 }

--- a/src/main/java/com/randomscreenshot/ScreenshotUtil.java
+++ b/src/main/java/com/randomscreenshot/ScreenshotUtil.java
@@ -35,8 +35,6 @@ import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.events.ScreenshotTaken;
 import net.runelite.client.ui.DrawManager;
@@ -53,17 +51,10 @@ public class ScreenshotUtil
 	@Inject
 	private EventBus eventBus;
 	@Inject
-	private Client client;
-	@Inject
 	private FileFactory fileFactory;
 	
 	public void takeScreenshot(String directory)
 	{
-		if (client.getGameState() == GameState.LOGIN_SCREEN)
-		{
-			return;
-		}
-
 		Consumer<Image> imageCallback = (img) ->
 		{
 			// This callback is on the game thread, move to executor thread


### PR DESCRIPTION
This implements #1.

I needed to copy over parts of `ImageCapture` because it hardcodes the runelite directory as the base directory.

Also, ideally the plugin config panel should use a file picker instead of a raw text input... however currently it doesn't appear as though the file picker (like the one used to import profiles) is available in the plugin panel.